### PR TITLE
Add local variables as references to instances

### DIFF
--- a/classes/multiorder/class-alg-mowc-core.php
+++ b/classes/multiorder/class-alg-mowc-core.php
@@ -10,6 +10,62 @@
 if ( ! class_exists( 'Alg_MOWC_Core' ) ) {
 
 	class Alg_MOWC_Core extends Alg_MOWC_WP_Plugin {
+		
+		/**
+		 * Order Metabox instance.
+		 *
+		 * @var Alg_MOWC_Multiorder_CMB
+		 */
+		public $order_metabox = null;
+		
+		/**
+		 * Order Manager instance.
+		 *
+		 * @var Alg_MOWC_Order_Manager
+		 */
+		public $order_manager = null;
+		
+		/**
+		 * Order Columns instance.
+		 *
+		 * @var Alg_MOWC_Order_Columns
+		 */
+		public $order_columns = null;
+		
+		/**
+		 * Orders View instance.
+		 *
+		 * @var Alg_MOWC_Orders_View
+		 */
+		public $orders_view = null;
+		
+		/**
+		 * Orders Search instance.
+		 *
+		 * @var Alg_MOWC_Orders_Search
+		 */
+		public $orders_search = null;
+		
+		/**
+		 * Order Item instance.
+		 *
+		 * @var Alg_MOWC_Order_Item
+		 */
+		public $order_item = null;
+		
+		/**
+		 * Order Actions instance.
+		 *
+		 * @var Alg_MOWC_Order_Actions
+		 */
+		public $order_actions = null;
+		
+		/**
+		 * WC Report instance.
+		 *
+		 * @var Alg_MOWC_WC_Report
+		 */
+		public $wc_report = null;
 
 		/**
 		 * Initializes the plugin.
@@ -51,14 +107,14 @@ if ( ! class_exists( 'Alg_MOWC_Core' ) ) {
 		 * @since   1.0.0
 		 */
 		public function setup_plugin() {
-			new Alg_MOWC_Multiorder_CMB();
-			new Alg_MOWC_Order_Manager();
-			new Alg_MOWC_Order_Columns();
-			new Alg_MOWC_Orders_View();
-			new Alg_MOWC_Orders_Search();
-			new Alg_MOWC_Order_Item();
-			new Alg_MOWC_Order_Actions();
-			new Alg_MOWC_WC_Report();
+			$this->order_metabox = new Alg_MOWC_Multiorder_CMB();
+			$this->order_manager = new Alg_MOWC_Order_Manager();
+			$this->order_columns = new Alg_MOWC_Order_Columns();
+			$this->orders_view = new Alg_MOWC_Orders_View();
+			$this->orders_search = new Alg_MOWC_Orders_Search();
+			$this->order_item = new Alg_MOWC_Order_Item();
+			$this->order_actions = new Alg_MOWC_Order_Actions();
+			$this->wc_report = new Alg_MOWC_WC_Report();
 		}
 
 		/**


### PR DESCRIPTION
Thanks for this plugin! It's awesome.

I have a specific requirement where I need to add certain products to one order and certain products to another, splitting them in a custom way.

This can be achieved if I am able to unhook `Alg_MOWC_Order_Manager::create_suborders_call_on_new_order` from `woocommerce_checkout_order_processed` and extend `Alg_MOWC_Order_Manager` with a class in my theme and write the `:create_suborders` in the way that i need to.

Then i get to keep using all the other awesome functionality you have guys have written.

So to be able to that, all i need is a reference to the `Alg_MOWC_Order_Manager` instance; with this pull request I can access this instance via `Alg_MOWC_Core::get_instance()->order_manager`.

For good measure I have added a reference to all instances to keep it all consistent.